### PR TITLE
Escape quotes in commit messages properly

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -26,8 +26,10 @@ export function git(
 function run(inputCommand: string, { verbose }: { verbose?: boolean } = { verbose: false }): Promise<string> {
 	let output = "";
 	const [cmd, ...args] = (
-		inputCommand.match(/[A-z0-9\-\_\:\/\\\.\@\!\#\$\%\^\&\*\(\)\{\}\[\]\;\<\>\=\+\~]+|"[^\"]+"|'[^\']+'/g) || []
-	).map(arg => arg.replace(/\"/g, ""));
+		inputCommand.match(
+			/[A-z0-9\-\_\:\/\\\.\@\!\#\$\%\^\&\*\(\)\{\}\[\]\;\<\>\=\+\~]+|"(?:[^\"]|(?<=\\)")+"|'(?:[^\']|(?<=\\)')+'/g
+		) || []
+	).map(arg => arg.replace(/^"|"$|\\(?="|')/g, ""));
 	if (DEBUG) console.log(`» ${inputCommand}`, cmd, args);
 	const child = spawn(cmd, args, { stdio: ["inherit", "pipe", "pipe"] });
 
@@ -136,7 +138,7 @@ export async function applyUpdate(commit: Commit) {
 }
 
 function generateUpdateCommitMessage(commit: Commit) {
-	return `🔄 ${commit.hash}: ${commit.message}`;
+	return `🔄 ${commit.hash}: ${commit.message.replace(/(["'$`\\])/g, '\\$1')}`;
 }
 
 function extractUpdateCommit(commit: Commit): Update | false {


### PR DESCRIPTION
Quotes in commit messages need to be escaped first, and removed only after splitting args