### PR TITLE
Allow empty commits

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -119,7 +119,7 @@ export async function applyUpdate(commit: Commit) {
 
 	async function successfullyCommits() {
 		try {
-			await git(`commit -m "${commitMessage}"`, { verbose: true });
+			await git(`commit --allow-empty -m "${commitMessage}"`, { verbose: true });
 			return true;
 		} catch (stderr) {
 			return stderr.includes("working tree clean");


### PR DESCRIPTION
First of all, thanks for this helpful tool 💐 

While testing it in one of our projects I came across the issue that a developer already incorporated changes made in the upstream template into the derived project by hand. 

When selecting the commit with that said change from the list of possible updates, the result was an empty commit (because changes where already made). Ending in the loop with the message "Resolve/stage conflicts and press any key to continue...". 

I think it would be better to allow such (already incorporated) updates to be picked and _applied_ because with the "git-upstream-template" commit in place, they will be filtered out of the list of possible updates. Also users won't get stuck in the above mentioned loop when changes have been made in both, the template project and derived one. 

What do you think? If you prefer this not to be a default option, we can introduce a separate flag users can pass into CLI?